### PR TITLE
Update snippets to work with Typescript files

### DIFF
--- a/snippets/blocks.cson
+++ b/snippets/blocks.cson
@@ -2,7 +2,7 @@
 # Block-level snippets
 ################################
 
-'.source.js':
+'.source.js, .source.ts':
 
   'Describe block':
     prefix: 'des'

--- a/snippets/expectations.cson
+++ b/snippets/expectations.cson
@@ -2,7 +2,7 @@
   # Expectations
   ################################
 
-'.source.js':
+'.source.js, .source.ts':
 
   'Expect not to be defined':
     prefix: 'notd'

--- a/snippets/spies.cson
+++ b/snippets/spies.cson
@@ -2,7 +2,7 @@
   # Spies
   ################################
 
-'.source.js':
+'.source.js, .source.ts':
 
   'spyOn':
     prefix: 'spy'


### PR DESCRIPTION
Since any valid javascript is also valid Typescript, it would be nice if these snippets would work with Typescript files as well for those opting to write their jasmine tests in Typescript.