### PR TITLE
Fix duplicate key problem in snippets

### DIFF
--- a/snippets/blocks.cson
+++ b/snippets/blocks.cson
@@ -93,7 +93,7 @@
       afterEach ->
       \t$1
     """
-  'After-Each block':
+  'After-Each Async block':
     prefix: 'aftA'
     body: """
       afterEach (${1:done}) ->


### PR DESCRIPTION
This caused an error in Atom v1.23.1

![image](https://user-images.githubusercontent.com/10676525/34917211-a07fd67e-f943-11e7-836b-d05c008a5c40.png)
